### PR TITLE
Fix object paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tame-gcs"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Embark <opensource@embark-studios.com>", "Jake Shadle <jake.shadle@embark-studios.com>"]
 edition = "2018"
 description = "A small library with a limited set of Google Cloud Storage operations"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tame-gcs"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Embark <opensource@embark-studios.com>", "Jake Shadle <jake.shadle@embark-studios.com>"]
 edition = "2018"
 description = "A small library with a limited set of Google Cloud Storage operations"

--- a/src/v1/objects/insert.rs
+++ b/src/v1/objects/insert.rs
@@ -84,9 +84,16 @@ impl super::Object {
     where
         OID: ObjectIdentifier<'a> + ?Sized,
     {
-        let mut uri = crate::__make_obj_url!(
+        let mut uri = format!(
             "https://www.googleapis.com/upload/storage/v1/b/{}/o?name={}&uploadType=media",
-            id
+            url::percent_encoding::percent_encode(
+                id.bucket().as_ref(),
+                url::percent_encoding::PATH_SEGMENT_ENCODE_SET,
+            ),
+            url::percent_encoding::percent_encode(
+                id.object().as_ref(),
+                url::percent_encoding::QUERY_ENCODE_SET,
+            ),
         );
 
         let query = optional.unwrap_or_default();

--- a/src/v1/objects/list.rs
+++ b/src/v1/objects/list.rs
@@ -77,6 +77,9 @@ where
         #[derive(Deserialize)]
         struct RawListResponse {
             next_page_token: Option<String>,
+            // This field won't be present if the list doesn't actually
+            // return any items
+            #[serde(default)]
             items: Vec<super::ObjectMetadata>,
         }
 

--- a/src/v1/objects/mod.rs
+++ b/src/v1/objects/mod.rs
@@ -13,7 +13,7 @@ macro_rules! __make_obj_url {
             ),
             url::percent_encoding::percent_encode(
                 $id.object().as_ref(),
-                url::percent_encoding::QUERY_ENCODE_SET
+                url::percent_encoding::PATH_SEGMENT_ENCODE_SET
             )
         )
     }};

--- a/tests/objects.rs
+++ b/tests/objects.rs
@@ -12,7 +12,7 @@ fn insert_vanilla() {
     let insert_req = Object::insert_simple(
         &(
             &BucketName::non_validated("bucket"),
-            &ObjectName::non_validated("object"),
+            &ObjectName::non_validated("object/with/deep/path"),
         ),
         "great content",
         13,
@@ -22,7 +22,7 @@ fn insert_vanilla() {
 
     let expected = http::Request::builder()
         .method(http::Method::POST)
-        .uri("https://www.googleapis.com/upload/storage/v1/b/bucket/o?name=object&uploadType=media&prettyPrint=false")
+        .uri("https://www.googleapis.com/upload/storage/v1/b/bucket/o?name=object/with/deep/path&uploadType=media&prettyPrint=false")
         .header(http::header::CONTENT_TYPE, "application/octet-stream")
         .header(http::header::CONTENT_LENGTH, 13)
         .body("great content")
@@ -56,11 +56,28 @@ fn insert_json_content() {
 }
 
 #[test]
+fn vanilla_get() {
+    let get_req = Object::get(
+        &ObjectId::new("bucket", "test/with/path_separators").unwrap(),
+        None,
+    )
+    .unwrap();
+
+    let expected = http::Request::builder()
+        .method(http::Method::GET)
+        .uri("https://www.googleapis.com/storage/v1/b/bucket/o/test%2Fwith%2Fpath_separators?alt=json&prettyPrint=false")
+        .body(std::io::empty())
+        .unwrap();
+
+    util::requests_eq(&get_req, &expected);
+}
+
+#[test]
 fn delete_vanilla() {
     let delete_req = Object::delete(
         &(
             &BucketName::non_validated("bucket"),
-            &ObjectName::non_validated("object"),
+            &ObjectName::non_validated("object/with/deep/path"),
         ),
         None,
     )
@@ -68,7 +85,7 @@ fn delete_vanilla() {
 
     let expected = http::Request::builder()
         .method(http::Method::DELETE)
-        .uri("https://www.googleapis.com/storage/v1/b/bucket/o/object?prettyPrint=false")
+        .uri("https://www.googleapis.com/storage/v1/b/bucket/o/object%2Fwith%2Fdeep%2Fpath?prettyPrint=false")
         .body(std::io::empty())
         .unwrap();
 

--- a/tests/objects.rs
+++ b/tests/objects.rs
@@ -179,3 +179,14 @@ fn parses_list_response() {
     assert_eq!(2, list_response.objects.len());
     assert!(list_response.page_token.is_none());
 }
+
+#[test]
+fn parses_empty_list_response() {
+    let body = r#"{"kind":"storage#objects"}"#;
+
+    let response = http::Response::new(body);
+    let list_response = objects::ListResponse::try_from(response).expect("parsed list response");
+
+    assert_eq!(0, list_response.objects.len());
+    assert!(list_response.page_token.is_none());
+}


### PR DESCRIPTION
Objects with path separators in their names weren't being serialized correctly except in the insert case as it is special and is one of the few that uses the name via query parameters instead of the path. Also corrected case where the list operation doesn't return any items.