### PR TITLE
Add multipart inserts

### DIFF
--- a/.ci/lint.sh
+++ b/.ci/lint.sh
@@ -25,6 +25,6 @@ travis_fold end "cargo.fetch"
 # Because rust isn't brutal enough itself
 travis_fold start "clippy"
     travis_time_start
-        cargo clippy -- -D warnings
+        cargo clippy --tests --examples --all-features -- -D warnings
     travis_time_finish
 travis_fold end "clippy"

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -42,6 +42,6 @@ travis_fold end "cargo.build"
 # Run the actual tests
 travis_fold start "cargo.test"
     travis_time_start
-        cargo test --target $TARGET
+        cargo test --target $TARGET --all-features
     travis_time_finish
 travis_fold end "cargo.test"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ base64 = "0.10.1"
 bytes = "0.4.12"
 chrono = { version = "0.4.7", features = ["serde"] }
 failure = "0.1.5"
-http = "0.1.17"
+http = "0.1.18"
 ring = { version = "0.14.6", optional = true }
-serde = { version = "1.0.94", features = ["derive"] }
+serde = { version = "1.0.98", features = ["derive"] }
 serde_json = "1.0.40"
 serde_urlencoded = "0.5.5"
 untrusted = { version = "0.6.2", optional = true }
@@ -29,7 +29,7 @@ url = "1.7.2"
 
 [dev-dependencies]
 # COLORS!
-ansi_term = "0.11.0"
+ansi_term = "0.12.0"
 # Diff view of test failures
 difference = "2.0.0"
 # Use environment for arguments
@@ -41,7 +41,7 @@ reqwest = { version = "0.9.19", default-features = false, features = ["rustls-tl
 # Because it's good
 structopt = "0.2.18"
 # For doing actual authentication in examples
-tame-oauth = { version = "0.2.0", features = ["gcp"] }
+tame-oauth = { version = "0.2.1", features = ["gcp"] }
 
 [features]
 default = ["v1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ url = "1.7.2"
 [dev-dependencies]
 # COLORS!
 ansi_term = "0.12.0"
+# Human friendly byte sizes
+number_prefix = "0.3.0"
 # Diff view of test failures
 difference = "2.0.0"
 # Use environment for arguments

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tame-gcs"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Embark <opensource@embark-studios.com>", "Jake Shadle <jake.shadle@embark-studios.com>"]
 edition = "2018"
 description = "A small library with a limited set of Google Cloud Storage operations"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tame-gcs"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["Embark <opensource@embark-studios.com>", "Jake Shadle <jake.shadle@embark-studios.com>"]
 edition = "2018"
 description = "A small library with a limited set of Google Cloud Storage operations"
@@ -10,6 +10,11 @@ homepage = "https://github.com/EmbarkStudios/tame-gcs"
 repository = "https://github.com/EmbarkStudios/tame-gcs"
 keywords = ["gcs", "tame", "sans-io", "storage", "gcp"]
 readme = "README.md"
+
+exclude = [
+  # End users don't want the JSON schemas
+  "src/v1/schema.json",
+]
 
 [lib]
 doctest = false

--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ to work with, if you don't care about what HTTP clients they use.
 
 ## Examples
 
-Coming soon, I promise!
+The examples directory includes a simplified version of [gsutil](https://cloud.google.com/storage/docs/gsutil). This
+is a work in progress that gives examples of using the different operations that are currently supported in this crate.
+
+* [cat](examples/gsutil/cat.rs) - Shows an example [Object::download](https://docs.rs/tame-gcs/latest/tame_gcs/objects/struct.Object.html#method.download)
+* [cp](examples/gsutil/cp.rs) - Shows an example of [Object::download](https://docs.rs/tame-gcs/latest/tame_gcs/objects/struct.Object.html#method.download) as well as [Object::insert_multipart](https://docs.rs/tame-gcs/latest/tame_gcs/objects/struct.Object.html#method.insert_multipart)
+* [ls](examples/gsutil/ls.rs) - Shows an example of [Object::list](https://docs.rs/tame-gcs/latest/tame_gcs/objects/struct.Object.html#method.list)
+* [signurl](examples/gsutil/signurl.rs) - Shows an example of [UrlSigner](https://docs.rs/tame-gcs/latest/tame_gcs/signed_url/struct.UrlSigner.html)
+* [stat](examples/gsutil/stat.rs) - Shows an example of [Object::get](https://docs.rs/tame-gcs/latest/tame_gcs/objects/struct.Object.html#method.get)
 
 ## Contributing
 

--- a/examples/gsutil/cat.rs
+++ b/examples/gsutil/cat.rs
@@ -28,7 +28,7 @@ last numbytes of the object."
 pub(crate) fn cmd(ctx: &util::RequestContext, args: Args) -> Result<(), Error> {
     let oid = util::gs_url_to_object_id(&args.url)?;
 
-    let mut download_req = Object::download(&oid, None)?;
+    let mut download_req = Object::download(&(oid.bucket(), oid.object().ok_or_else(|| failure::format_err!("invalid object name specified"))?), None)?;
 
     if let Some(range) = args.range {
         // The format specified in the arguments exactly matches those HTTP range

--- a/examples/gsutil/cat.rs
+++ b/examples/gsutil/cat.rs
@@ -28,7 +28,14 @@ last numbytes of the object."
 pub(crate) fn cmd(ctx: &util::RequestContext, args: Args) -> Result<(), Error> {
     let oid = util::gs_url_to_object_id(&args.url)?;
 
-    let mut download_req = Object::download(&(oid.bucket(), oid.object().ok_or_else(|| failure::format_err!("invalid object name specified"))?), None)?;
+    let mut download_req = Object::download(
+        &(
+            oid.bucket(),
+            oid.object()
+                .ok_or_else(|| failure::format_err!("invalid object name specified"))?,
+        ),
+        None,
+    )?;
 
     if let Some(range) = args.range {
         // The format specified in the arguments exactly matches those HTTP range

--- a/examples/gsutil/cp.rs
+++ b/examples/gsutil/cp.rs
@@ -1,0 +1,110 @@
+use crate::util;
+use failure::{bail, Error, ResultExt};
+use std::{convert::TryFrom, path::PathBuf};
+use structopt::StructOpt;
+use tame_gcs::objects::{self, Metadata, Object};
+
+#[derive(StructOpt, Debug)]
+pub(crate) struct Args {
+    /// A gs: URL or filepath for the source path to copy from,
+    /// wildcards are not currently supported
+    src_url: String,
+    /// A gs: URL or filepath for the destination to copy to,
+    /// wildcards are not currently supported
+    dest_url: String,
+}
+
+enum DataPath {
+    Gs(util::GsUrl),
+    File(PathBuf),
+}
+
+impl DataPath {
+    fn is_file(&self) -> bool {
+        if let DataPath::File(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl TryFrom<String> for DataPath {
+    type Error = Error;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if s.starts_with("gs://") {
+            let url = url::Url::parse(&s)?;
+            Ok(DataPath::Gs(util::gs_url_to_object_id(&url)?))
+        } else {
+            Ok(DataPath::File(PathBuf::from(s)))
+        }
+    }
+}
+
+// cp is probably gsutil's most complicated subcommand, so we only implement
+// a bare minimum
+pub(crate) fn cmd(ctx: &util::RequestContext, args: Args) -> Result<(), Error> {
+    use std::fs;
+
+    let src = DataPath::try_from(args.src_url)?;
+    let dst = DataPath::try_from(args.dest_url)?;
+
+    // Just support gcs to local or vice versa, not local to local or gcs to gcs
+    if src.is_file() == dst.is_file() {
+        let location = if src.is_file() { "local disk" } else { "gcs" };
+
+        bail!("source and destination are both located on {}", location)
+    }
+
+    match (&src, &dst) {
+        (DataPath::File(ref src), DataPath::Gs(dst)) => {
+            let src_file = fs::File::open(src).context("source path")?;
+            let src_len = src_file.metadata()?.len();
+
+            let obj_name = format!(
+                "{}{}{}",
+                dst.object().map(|on| on.as_ref()).unwrap_or(""),
+                if dst.object().is_some() { "/" } else { "" },
+                src.file_name()
+                    .as_ref()
+                    .and_then(|os| os.to_str())
+                    .ok_or_else(|| failure::format_err!("can't turn file_name into string"))?
+            );
+            let insert_req = Object::insert_multipart(
+                dst.bucket(),
+                src_file,
+                src_len,
+                &Metadata {
+                    name: Some(obj_name),
+                    ..Default::default()
+                },
+                None,
+            )?;
+
+            let _insert_res: objects::InsertResponse = util::execute(ctx, insert_req)?;
+
+            Ok(())
+        }
+        (DataPath::Gs(src), DataPath::File(dst)) => {
+            let mut dst_file = fs::File::create(dst).context("destination path")?;
+
+            let dl_req = Object::download(
+                &(
+                    src.bucket(),
+                    src.object().ok_or_else(|| {
+                        failure::format_err!("must provide a full object name to copy from")
+                    })?,
+                ),
+                None,
+            )?;
+
+            let mut response: objects::DownloadObjectResponse = util::execute(ctx, dl_req)?;
+
+            std::io::copy(&mut response, &mut dst_file)?;
+
+            Ok(())
+        }
+        _ => unreachable!(),
+    }
+}

--- a/examples/gsutil/ls.rs
+++ b/examples/gsutil/ls.rs
@@ -1,0 +1,225 @@
+use crate::util;
+use ansi_term::Color;
+use failure::Error;
+use structopt::StructOpt;
+use tame_gcs::{
+    common::StandardQueryParameters,
+    objects::{ListOptional, ListResponse, Metadata, Object},
+};
+
+#[derive(StructOpt, Debug)]
+pub(crate) struct Args {
+    /// Recurse into directories (not implemented!)
+    #[structopt(short = "R", long)]
+    recurse: bool,
+    /// Displays extended metadata as a table
+    #[structopt(short = "l", long)]
+    long: bool,
+    /// The gs:// url list out
+    url: url::Url,
+}
+
+pub(crate) fn cmd(ctx: &util::RequestContext, args: Args) -> Result<(), Error> {
+    let oid = util::gs_url_to_object_id(&args.url)?;
+
+    let delimiter = if args.recurse { None } else { Some("/") };
+    let mut prefix = oid.object().map(|on| on.as_ref()).unwrap_or("").to_owned();
+    if !prefix.is_empty() && !prefix.ends_with("/") {
+        prefix.push('/')
+    }
+
+    let prefix_len = prefix.len();
+    let prefix = Some(prefix);
+
+    let display = if args.long {
+        Display::Long
+    } else {
+        Display::Normal
+    };
+
+    let mut normal = None;
+    //let recurse = None;
+    if args.recurse {
+        // recurse = Some(RecursePrinter {
+        //     display,
+        //     prefix_len,
+        //     dirs: HashSet::new(),
+        // });
+    } else {
+        normal = Some(NormalPrinter {
+            display,
+            prefix_len,
+        });
+    }
+
+    let fields = match display {
+        Display::Normal => "items(name), prefixes, nextPageToken",
+        Display::Long => "items(name, updated, size), prefixes, nextPageToken",
+    };
+
+    let mut page_token: Option<String> = None;
+    loop {
+        let ls_req = Object::list(
+            oid.bucket(),
+            Some(ListOptional {
+                delimiter,
+                page_token: page_token.as_ref().map(|pt| pt.as_ref()),
+                prefix: prefix.as_ref().map(|s| s.as_ref()),
+                standard_params: StandardQueryParameters {
+                    fields: Some(fields),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        )?;
+
+        let ls_res: ListResponse = util::execute(ctx, ls_req)?;
+
+        if let Some(ref np) = normal {
+            np.print(ls_res.objects, ls_res.prefixes);
+        }
+        // } else if let Some(ref mut rec) = recurse {
+        //     rec.print(ls_res.objects);
+        // }
+
+        // If we have a page token it means there may be more items
+        // that fulfill the parameters
+        page_token = ls_res.page_token;
+        if page_token.is_none() {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Copy, Clone)]
+enum Display {
+    Normal,
+    Long,
+}
+
+struct NormalPrinter {
+    display: Display,
+    prefix_len: usize,
+}
+
+fn print_dir(display: Display, dir: &str) {
+    match display {
+        Display::Normal => println!("{}", Color::Blue.bold().paint(dir)),
+        Display::Long => println!(
+            "    {} {} {} {}",
+            Color::White.dimmed().paint("-"),
+            Color::White.dimmed().paint("  -"),
+            Color::White.dimmed().paint("-- --- --:--:--"),
+            Color::Blue.bold().paint(dir),
+        ),
+    }
+}
+
+impl NormalPrinter {
+    fn print(&self, items: Vec<Metadata>, prefixes: Vec<String>) {
+        let indices = {
+            // Determine at which indices we should place the "directories"
+            let mut indices = Vec::with_capacity(prefixes.len());
+
+            // So yah...just assume these are always in sorted order...
+            for prefix in &prefixes {
+                if let Err(i) = items.binary_search_by(|om| om.name.as_ref().unwrap().cmp(&prefix))
+                {
+                    indices.push(i);
+                }
+            }
+
+            indices
+        };
+
+        let mut next_dir_iter = indices.iter().enumerate();
+        let mut next_dir = next_dir_iter.next();
+
+        for (i, item) in items.into_iter().enumerate() {
+            if let Some(nd) = next_dir {
+                if *nd.1 == i {
+                    let dir = &(&prefixes[nd.0])[self.prefix_len..];
+                    let dir = &dir[..dir.len() - 1]; // Remove trailing delimiter
+
+                    print_dir(self.display, dir);
+
+                    std::mem::replace(&mut next_dir, next_dir_iter.next());
+                }
+            }
+
+            let filename = &item.name.unwrap()[self.prefix_len..];
+
+            match self.display {
+                Display::Normal => println!("{}", Color::White.paint(filename)),
+                Display::Long => {
+                    use number_prefix::{NumberPrefix, PrefixNames, Prefixed, Standalone};
+
+                    let size_str = match NumberPrefix::decimal(item.size.unwrap_or_default() as f64)
+                    {
+                        Standalone(b) => b.to_string(),
+                        Prefixed(p, n) => {
+                            if n < 10f64 {
+                                format!("{:.1}{}", n, p.symbol())
+                            } else {
+                                format!("{:.0}{}", n, p.symbol())
+                            }
+                        }
+                    };
+
+                    let updated = item.updated.unwrap();
+                    let updated_str = updated.format("%d %b %T").to_string();
+
+                    println!(
+                        " {}{} {} {} {}",
+                        if size_str.len() < 4 { " " } else { "" },
+                        Color::Green.paint(size_str),
+                        Color::Yellow.paint("gcs"),
+                        Color::Blue.paint(updated_str),
+                        Color::White.paint(filename),
+                    );
+                }
+            }
+        }
+
+        while let Some(nd) = next_dir {
+            let dir = &(&prefixes[nd.0])[self.prefix_len..];
+            let dir = &dir[..dir.len() - 1]; // Remove trailing delimiter
+
+            print_dir(self.display, dir);
+
+            std::mem::replace(&mut next_dir, next_dir_iter.next());
+        }
+    }
+}
+
+// struct RecursePrinter {
+//     display: Display,
+//     prefix_len: usize,
+//     dir_stack: Vec<String>,
+// }
+
+// impl RecursePrinter {
+//     fn print(&mut self, items: Vec<Metadata>) {
+//         for item in items {
+//             let filename = &item.name.unwrap()[self.prefix_len..];
+
+//             self.write_dirs(filename);
+//         }
+//     }
+
+//     fn write_dirs(&mut self, filename: &str) {
+//         if let Some(sep) = filename.rfind('/') {
+//             let filename = &filename[..sep];
+
+//             let mut dir_name = String::new();
+//             for part in filename.split('/') {
+//                 dir_name.push_str(part);
+
+//                 if !self.dirs.contains(&dir_name) {
+//                 }
+//             }
+//         }
+//     }
+// }

--- a/examples/gsutil/ls.rs
+++ b/examples/gsutil/ls.rs
@@ -24,7 +24,7 @@ pub(crate) fn cmd(ctx: &util::RequestContext, args: Args) -> Result<(), Error> {
 
     let delimiter = if args.recurse { None } else { Some("/") };
     let mut prefix = oid.object().map(|on| on.as_ref()).unwrap_or("").to_owned();
-    if !prefix.is_empty() && !prefix.ends_with("/") {
+    if !prefix.is_empty() && !prefix.ends_with('/') {
         prefix.push('/')
     }
 

--- a/examples/gsutil/main.rs
+++ b/examples/gsutil/main.rs
@@ -6,6 +6,7 @@ use structopt::StructOpt;
 mod cat;
 #[cfg(feature = "signing")]
 mod signurl;
+mod stat;
 mod util;
 
 #[derive(StructOpt)]
@@ -16,6 +17,8 @@ enum Command {
     #[cfg(feature = "signing")]
     #[structopt(name = "signurl")]
     Signurl(signurl::Args),
+    #[structopt(name = "stat")]
+    Stat(stat::Args),
 }
 
 #[derive(StructOpt)]
@@ -55,6 +58,7 @@ fn real_main() -> Result<(), Error> {
         Command::Cat(args) => cat::cmd(&ctx, args),
         #[cfg(feature = "signing")]
         Command::Signurl(args) => signurl::cmd(&ctx, args),
+        Command::Stat(args) => stat::cmd(&ctx, args),
     }
 }
 

--- a/examples/gsutil/main.rs
+++ b/examples/gsutil/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 mod cat;
+mod cp;
 #[cfg(feature = "signing")]
 mod signurl;
 mod stat;
@@ -14,6 +15,9 @@ enum Command {
     /// Concatenate object content to stdout
     #[structopt(name = "cat")]
     Cat(cat::Args),
+    /// Copy files and objects
+    #[structopt(name = "cp")]
+    Cp(cp::Args),
     #[cfg(feature = "signing")]
     #[structopt(name = "signurl")]
     Signurl(signurl::Args),
@@ -56,6 +60,7 @@ fn real_main() -> Result<(), Error> {
 
     match args.cmd {
         Command::Cat(args) => cat::cmd(&ctx, args),
+        Command::Cp(args) => cp::cmd(&ctx, args),
         #[cfg(feature = "signing")]
         Command::Signurl(args) => signurl::cmd(&ctx, args),
         Command::Stat(args) => stat::cmd(&ctx, args),

--- a/examples/gsutil/main.rs
+++ b/examples/gsutil/main.rs
@@ -54,7 +54,7 @@ fn real_main() -> Result<(), Error> {
 
     let ctx = util::RequestContext {
         client,
-        cred_path: cred_path,
+        cred_path,
         auth: std::sync::Arc::new(svc_account_access),
     };
 

--- a/examples/gsutil/main.rs
+++ b/examples/gsutil/main.rs
@@ -5,6 +5,7 @@ use structopt::StructOpt;
 
 mod cat;
 mod cp;
+mod ls;
 #[cfg(feature = "signing")]
 mod signurl;
 mod stat;
@@ -18,6 +19,8 @@ enum Command {
     /// Copy files and objects
     #[structopt(name = "cp")]
     Cp(cp::Args),
+    #[structopt(name = "ls")]
+    Ls(ls::Args),
     #[cfg(feature = "signing")]
     #[structopt(name = "signurl")]
     Signurl(signurl::Args),
@@ -61,6 +64,7 @@ fn real_main() -> Result<(), Error> {
     match args.cmd {
         Command::Cat(args) => cat::cmd(&ctx, args),
         Command::Cp(args) => cp::cmd(&ctx, args),
+        Command::Ls(args) => ls::cmd(&ctx, args),
         #[cfg(feature = "signing")]
         Command::Signurl(args) => signurl::cmd(&ctx, args),
         Command::Stat(args) => stat::cmd(&ctx, args),

--- a/examples/gsutil/signurl.rs
+++ b/examples/gsutil/signurl.rs
@@ -110,7 +110,15 @@ pub(crate) fn cmd(ctx: &util::RequestContext, args: Args) -> Result<(), Error> {
         }
     };
 
-    let signed_url = url_signer.generate(&service_account, &oid, options)?;
+    let signed_url = url_signer.generate(
+        &service_account,
+        &(
+            oid.bucket(),
+            oid.object()
+                .ok_or_else(|| failure::format_err!("must have a valid object name"))?,
+        ),
+        options,
+    )?;
 
     println!("{}", signed_url);
 

--- a/examples/gsutil/stat.rs
+++ b/examples/gsutil/stat.rs
@@ -1,0 +1,56 @@
+use crate::util;
+use failure::Error;
+use structopt::StructOpt;
+use tame_gcs::objects::Object;
+
+#[derive(StructOpt, Debug)]
+pub(crate) struct Args {
+    /// The gs:// url to the object to stat
+    url: url::Url,
+}
+
+pub(crate) fn cmd(ctx: &util::RequestContext, args: Args) -> Result<(), Error> {
+    let oid = util::gs_url_to_object_id(&args.url)?;
+
+    let get_req = Object::get(
+        &(
+            oid.bucket(),
+            oid.object()
+                .ok_or_else(|| failure::format_err!("invalid object name specified"))?,
+        ),
+        None,
+    )?;
+    let get_res: tame_gcs::objects::GetObjectResponse = util::execute(ctx, get_req)?;
+
+    let md = get_res.metadata;
+
+    // Print out the information the same way gsutil does, except with RFC-2822 date formatting
+    println!("{}", ansi_term::Color::Cyan.paint(args.url.as_str()));
+    println!(
+        "    Creation time:\t{}",
+        md.time_created.expect("time_created").to_rfc2822()
+    );
+    println!(
+        "    Update time:\t{}",
+        md.updated.expect("updated").to_rfc2822()
+    );
+    println!(
+        "    Storage class:\t{}",
+        md.storage_class.expect("storage_class")
+    );
+    println!("    Content-Length:\t{}", md.size.expect("size"));
+    println!(
+        "    Content-Type:\t{}",
+        md.content_type.expect("content_type")
+    );
+    println!("    Hash (crc32c):\t{}", md.crc32c.expect("crc32c"));
+    println!("    Hash (md5):\t\t{}", md.md5_hash.expect("md5_hash"));
+    println!("    ETag:\t\t{}", md.etag.expect("etag"));
+    println!("    Generation:\t\t{}", md.generation.expect("generation"));
+    println!(
+        "    Metageneration:\t{}",
+        md.metageneration.expect("metageneration")
+    );
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,8 @@
+//! Error facilities
+
 use std::fmt;
 
+/// Core error type for all errors possible from tame-gcs
 #[derive(Fail, Debug, PartialEq)]
 pub enum Error {
     #[fail(display = "Expected {}-{} characters, found {}", min, max, len)]

--- a/src/signed_url.rs
+++ b/src/signed_url.rs
@@ -1,3 +1,5 @@
+//! Facilities for [signed URLs](https://cloud.google.com/storage/docs/access-control/signed-urls),
+
 use crate::{error::Error, signing, types::ObjectIdentifier};
 use std::borrow::Cow;
 use url::{percent_encoding as perc_enc, Url};
@@ -5,7 +7,7 @@ use url::{percent_encoding as perc_enc, Url};
 /// A generator for [signed URLs](https://cloud.google.com/storage/docs/access-control/signed-urls),
 /// which can be used to grant temporary access to specific storage
 /// resources even if the client making the request is not otherwise
-/// logged in or normally has access to the storage resources in question.
+/// logged in or normally able to access to the storage resources in question.
 ///
 /// This implements the [V4 signing process](https://cloud.google.com/storage/docs/access-control/signing-urls-manually)
 pub struct UrlSigner<D, S> {
@@ -258,6 +260,7 @@ where
     }
 }
 
+/// Optional parameters that can be used to tweak url signing
 pub struct SignedUrlOptional<'a> {
     /// The HTTP method for the request to sign. Defaults to 'GET'.
     pub method: http::Method,

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -1,3 +1,5 @@
+//! Helper facilities for calculating content digests and signing data
+
 use crate::error::Error;
 use std::fmt;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+//! Helper types for working with GCS
+
 use crate::error::Error;
 use std::{borrow::Cow, convert::TryFrom};
 
@@ -249,6 +251,8 @@ where
     }
 }
 
+/// A concrete object id which contains a valid bucket and object name
+/// which fully specifies an object
 pub struct ObjectId<'a> {
     bucket: BucketName<'a>,
     object: ObjectName<'a>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+#![doc(hidden)]
+
 pub(crate) fn to_hex<'a>(input: &[u8], output: &'a mut [u8]) -> Option<&'a str> {
     use std::str;
 

--- a/src/v1/common.rs
+++ b/src/v1/common.rs
@@ -1,3 +1,5 @@
+//! Types that are commone between different operations.
+
 use std::fmt;
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -47,6 +49,8 @@ impl<'a> Default for StandardQueryParameters<'a> {
     }
 }
 
+/// Contains common conditionals that determite whether an operation
+/// will actually proceed or not
 #[derive(Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Conditionals {
@@ -116,6 +120,11 @@ impl fmt::Display for StorageClass {
     }
 }
 
+/// A [predefined or "canned" ACL](https://cloud.google.com/storage/docs/access-control/lists#predefined-acl)
+/// is an alias for a set of specific ACL entries that you can use to quickly apply many ACL entries at once
+/// to a bucket or object. Predefined ACLs are defined for common scenarios such as revoking all access
+/// permissions except for owner permission (predefined ACL private), or making an object publicly readable
+/// (predefined ACL publicRead).
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum PredefinedAcl {
@@ -133,6 +142,7 @@ pub enum PredefinedAcl {
     PublicRead,
 }
 
+/// Set of properties to return. Defaults to NoAcl.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Projection {
@@ -140,4 +150,10 @@ pub enum Projection {
     Full,
     /// Omit the owner, acl property.
     NoAcl,
+}
+
+impl Default for Projection {
+    fn default() -> Self {
+        Projection::NoAcl
+    }
 }

--- a/src/v1/common.rs
+++ b/src/v1/common.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn pretty_on(pretty_print: &bool) -> bool {
     *pretty_print
@@ -70,7 +72,7 @@ pub struct Conditionals {
 }
 
 /// [Storage classes](https://cloud.google.com/storage/docs/storage-classes)
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum StorageClass {
     /// [Multi-Regional Storage](https://cloud.google.com/storage/docs/storage-classes#multi-regional)
@@ -106,6 +108,12 @@ pub enum StorageClass {
     /// Regional Storage also has better performance, particularly in terms of availability
     /// (DRA has a 99% availability SLA).
     DurableReducedAvailability,
+}
+
+impl fmt::Display for StorageClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 #[derive(Serialize)]

--- a/src/v1/objects/get.rs
+++ b/src/v1/objects/get.rs
@@ -27,7 +27,7 @@ pub struct GetObjectOptional<'a> {
 }
 
 pub struct GetObjectResponse {
-    pub metadata: super::ObjectMetadata,
+    pub metadata: super::Metadata,
 }
 
 impl ApiResponse<&[u8]> for GetObjectResponse {}
@@ -41,7 +41,7 @@ where
 
     fn try_from(response: http::Response<B>) -> Result<Self, Self::Error> {
         let (_parts, body) = response.into_parts();
-        let metadata: super::ObjectMetadata = serde_json::from_slice(body.as_ref())?;
+        let metadata: super::Metadata = serde_json::from_slice(body.as_ref())?;
         Ok(Self { metadata })
     }
 }

--- a/src/v1/objects/insert.rs
+++ b/src/v1/objects/insert.rs
@@ -2,9 +2,9 @@ use crate::{
     common::{Conditionals, PredefinedAcl, Projection, StandardQueryParameters},
     error::Error,
     response::ApiResponse,
-    types::ObjectIdentifier,
+    types::{BucketName, ObjectIdentifier, ObjectName},
 };
-use std::convert::TryFrom;
+use std::{convert::TryFrom, io};
 
 /// Optional parameters when inserting an object.
 /// See [here](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#parameters)
@@ -60,6 +60,174 @@ where
         let (_parts, body) = response.into_parts();
         let metadata: super::Metadata = serde_json::from_slice(body.as_ref())?;
         Ok(Self { metadata })
+    }
+}
+
+const MULTI_PART_SEPARATOR: &[u8] = b"--tame_gcs\n";
+const MULTI_PART_SUFFIX: &[u8] = b"\n--tame_gcs--";
+const MULTI_PART_CT: &[u8] = b"content-type: application/json; charset=utf-8\n\n";
+
+enum MultipartPart {
+    Prefix,
+    Body,
+    Suffix,
+    End,
+}
+
+impl MultipartPart {
+    fn next(&mut self) {
+        match self {
+            MultipartPart::Prefix => *self = MultipartPart::Body,
+            MultipartPart::Body => *self = MultipartPart::Suffix,
+            MultipartPart::Suffix => *self = MultipartPart::End,
+            MultipartPart::End => unreachable!(),
+        }
+    }
+}
+
+struct MultipartCursor {
+    position: usize,
+    part: MultipartPart,
+}
+
+/// A multipart payload that should be used as the body of a multipart
+/// insert request
+pub struct Multipart<B> {
+    body: B,
+    prefix: bytes::Bytes,
+    body_len: u64,
+    total_len: u64,
+    cursor: MultipartCursor,
+}
+
+impl<B> Multipart<B> {
+    /// Wraps some body content and its metadata into a Multipart suitable for being
+    /// sent as an HTTP request body, the body will need to implement `std::io::Read`
+    /// to be able to be used as intended.
+    pub fn wrap(body: B, body_length: u64, metadata: &super::Metadata) -> Result<Self, Error> {
+        use bytes::BufMut;
+
+        const CT_HN: &[u8] = b"content-type: ";
+
+        // I wonder if this counts as sansio...
+        let serialized_metadata = serde_json::to_vec(metadata)?;
+        let content_type = metadata
+            .content_type
+            .as_ref()
+            .map(|s| s.as_str())
+            .unwrap_or_else(|| "application/octet-stream")
+            .as_bytes();
+
+        let metadata = &serialized_metadata[..];
+
+        // Example request from https://cloud.google.com/storage/docs/json_api/v1/how-tos/multipart-upload
+        // POST https://www.googleapis.com/upload/storage/v1/b/myBucket/o?uploadType=multipart HTTP/1.1
+        // Authorization: Bearer [YOUR_AUTH_TOKEN]
+        // Content-Type: multipart/related; boundary=foo_bar_baz
+        // Content-Length: [NUMBER_OF_BYTES_IN_ENTIRE_REQUEST_BODY]
+
+        // --foo_bar_baz
+        // Content-Type: application/json; charset=UTF-8
+
+        // {
+        // "name": "myObject"
+        // }
+
+        // --foo_bar_baz
+        // Content-Type: image/jpeg
+
+        // [JPEG_DATA]
+        // --foo_bar_baz--
+        let prefix_len = MULTI_PART_SEPARATOR.len()
+            + MULTI_PART_CT.len()
+            + metadata.len()
+            + 1
+            + MULTI_PART_SEPARATOR.len()
+            + CT_HN.len()
+            + content_type.len()
+            + 2;
+
+        let prefix = {
+            let mut prefix = bytes::BytesMut::with_capacity(prefix_len);
+            prefix.put_slice(MULTI_PART_SEPARATOR);
+            prefix.put_slice(MULTI_PART_CT);
+            prefix.put_slice(metadata);
+            prefix.put_slice(b"\n");
+            prefix.put_slice(MULTI_PART_SEPARATOR);
+            prefix.put_slice(CT_HN);
+            prefix.put_slice(content_type);
+            prefix.put_slice(b"\n\n");
+
+            prefix.freeze()
+        };
+
+        let total_len = prefix_len as u64 + body_length + MULTI_PART_SUFFIX.len() as u64;
+
+        Ok(Self {
+            body,
+            prefix,
+            body_len: body_length,
+            total_len,
+            cursor: MultipartCursor {
+                position: 0,
+                part: MultipartPart::Prefix,
+            },
+        })
+    }
+
+    /// The total length (Content-Length) of this multipart body
+    pub fn total_len(&self) -> u64 {
+        self.total_len
+    }
+}
+
+impl<B> io::Read for Multipart<B>
+where
+    B: io::Read,
+{
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        use std::cmp::min;
+        let mut total_copied = 0;
+
+        while total_copied < buffer.len() {
+            let buf = &mut buffer[total_copied..];
+
+            let (copied, len) = match self.cursor.part {
+                MultipartPart::Prefix => {
+                    let to_copy = min(buf.len(), self.prefix.len() - self.cursor.position);
+
+                    buf[..to_copy].copy_from_slice(
+                        &self.prefix[self.cursor.position..self.cursor.position + to_copy],
+                    );
+
+                    (to_copy, self.prefix.len())
+                }
+                MultipartPart::Body => {
+                    let copied = self.body.read(buf)?;
+                    (copied, self.body_len as usize)
+                }
+                MultipartPart::Suffix => {
+                    let to_copy = min(buf.len(), MULTI_PART_SUFFIX.len() - self.cursor.position);
+
+                    buf[..to_copy].copy_from_slice(
+                        &MULTI_PART_SUFFIX[self.cursor.position..self.cursor.position + to_copy],
+                    );
+
+                    (to_copy, MULTI_PART_SUFFIX.len())
+                }
+                MultipartPart::End => return Ok(total_copied),
+            };
+
+            self.cursor.position += copied;
+            total_copied += copied;
+
+            if self.cursor.position == len {
+                self.cursor.part.next();
+                self.cursor.position = 0;
+            }
+        }
+
+        Ok(total_copied)
     }
 }
 
@@ -119,5 +287,75 @@ impl super::Object {
         }
 
         Ok(req_builder.method("POST").uri(uri).body(content)?)
+    }
+
+    /// Stores a new object and metadata.
+    ///
+    /// * Maximum file size: `5TB`
+    /// * Accepted Media MIME types: `*/*`
+    ///
+    /// This method differs from `insert_simple` in that it performs a
+    /// [multipart upload](https://cloud.google.com/storage/docs/json_api/v1/how-tos/multipart-upload)
+    /// which allows you specify both the object data and its metadata in a single
+    /// request, instead of having to do an additional request to set the metadata.
+    ///
+    /// **NOTE**: You **must** specify the `name` field in the metadata provided to this function
+    /// with a valid object name. Only the `content_type` specified in `metadata` will be used,
+    /// the `content_type` in `optional` will be ignored.
+    ///
+    /// Required IAM Permissions: `storage.objects.create`, `storage.objects.delete`
+    ///
+    /// Note: `storage.objects.delete` is only needed if an object with the same
+    /// name already exists.
+    ///
+    /// [Complete API Documentation](https://cloud.google.com/storage/docs/json_api/v1/objects/insert)
+    pub fn insert_multipart<B>(
+        bucket: &BucketName<'_>,
+        content: B,
+        length: u64,
+        metadata: &super::Metadata,
+        optional: Option<InsertObjectOptional<'_>>,
+    ) -> Result<http::Request<Multipart<B>>, Error> {
+        // Since the user can specify the name in the metadata, we just always
+        // use that
+        match metadata.name {
+            Some(ref name) => ObjectName::try_from(name.as_ref())?,
+            None => {
+                return Err(Error::InvalidLength {
+                    len: 0,
+                    min: 1,
+                    max: 1024,
+                })
+            }
+        };
+
+        let mut uri = format!(
+            "https://www.googleapis.com/upload/storage/v1/b/{}/o?uploadType=multipart",
+            url::percent_encoding::percent_encode(
+                bucket.as_ref(),
+                url::percent_encoding::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+
+        let query = optional.unwrap_or_default();
+
+        let mut req_builder = http::Request::builder();
+
+        req_builder.header(
+            http::header::CONTENT_TYPE,
+            http::header::HeaderValue::from_static("multipart/related; boundary=tame_gcs"),
+        );
+
+        let multipart = Multipart::wrap(content, length, metadata)?;
+
+        req_builder.header(http::header::CONTENT_LENGTH, multipart.total_len());
+
+        let query_params = serde_urlencoded::to_string(query)?;
+        if !query_params.is_empty() {
+            uri.push('&');
+            uri.push_str(&query_params);
+        }
+
+        Ok(req_builder.method("POST").uri(uri).body(multipart)?)
     }
 }

--- a/src/v1/objects/insert.rs
+++ b/src/v1/objects/insert.rs
@@ -43,14 +43,14 @@ pub struct InsertObjectOptional<'a> {
 
 /// The response from an insert request is the Object [metadata](https://cloud.google.com/storage/docs/json_api/v1/objects#resource)
 /// for the newly inserted Object
-pub struct InsertObjectResponse {
-    pub metadata: super::ObjectMetadata,
+pub struct InsertResponse {
+    pub metadata: super::Metadata,
 }
 
-impl ApiResponse<&[u8]> for InsertObjectResponse {}
-impl ApiResponse<bytes::Bytes> for InsertObjectResponse {}
+impl ApiResponse<&[u8]> for InsertResponse {}
+impl ApiResponse<bytes::Bytes> for InsertResponse {}
 
-impl<B> TryFrom<http::Response<B>> for InsertObjectResponse
+impl<B> TryFrom<http::Response<B>> for InsertResponse
 where
     B: AsRef<[u8]>,
 {
@@ -58,7 +58,7 @@ where
 
     fn try_from(response: http::Response<B>) -> Result<Self, Self::Error> {
         let (_parts, body) = response.into_parts();
-        let metadata: super::ObjectMetadata = serde_json::from_slice(body.as_ref())?;
+        let metadata: super::Metadata = serde_json::from_slice(body.as_ref())?;
         Ok(Self { metadata })
     }
 }

--- a/src/v1/objects/list.rs
+++ b/src/v1/objects/list.rs
@@ -58,7 +58,7 @@ pub struct ListOptional<'a> {
 }
 
 pub struct ListResponse {
-    pub objects: Vec<super::ObjectMetadata>,
+    pub objects: Vec<super::Metadata>,
     pub page_token: Option<String>,
 }
 
@@ -80,7 +80,7 @@ where
             // This field won't be present if the list doesn't actually
             // return any items
             #[serde(default)]
-            items: Vec<super::ObjectMetadata>,
+            items: Vec<super::Metadata>,
         }
 
         let res: RawListResponse = serde_json::from_slice(body.as_ref())?;

--- a/src/v1/objects/list.rs
+++ b/src/v1/objects/list.rs
@@ -58,7 +58,14 @@ pub struct ListOptional<'a> {
 }
 
 pub struct ListResponse {
+    /// The list of objects matching the query
     pub objects: Vec<super::Metadata>,
+    /// The list of prefixes of objects matching-but-not-listed up to
+    /// and including the requested delimiter.
+    pub prefixes: Vec<String>,
+    /// The continuation token, included only if there are more items to return.
+    /// Provide this value as the page_token of a subsequent request in order
+    /// to return the next page of results.
     pub page_token: Option<String>,
 }
 
@@ -75,8 +82,11 @@ where
         let (_parts, body) = response.into_parts();
 
         #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct RawListResponse {
             next_page_token: Option<String>,
+            #[serde(default)]
+            prefixes: Vec<String>,
             // This field won't be present if the list doesn't actually
             // return any items
             #[serde(default)]
@@ -87,6 +97,7 @@ where
 
         Ok(Self {
             objects: res.items,
+            prefixes: res.prefixes,
             page_token: res.next_page_token,
         })
     }
@@ -102,7 +113,7 @@ impl super::Object {
         bucket: &BucketName<'_>,
         optional: Option<ListOptional<'_>>,
     ) -> Result<http::Request<std::io::Empty>, Error> {
-        let mut uri = format!("https://www.googleapis.com/storage/v1/b/{}/o", bucket,);
+        let mut uri = format!("https://www.googleapis.com/storage/v1/b/{}/o", bucket);
 
         let query = optional.unwrap_or_default();
         let query_params = serde_urlencoded::to_string(query)?;

--- a/src/v1/objects/mod.rs
+++ b/src/v1/objects/mod.rs
@@ -37,9 +37,7 @@ pub struct Object;
 /// associated with an Object.
 #[derive(Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ObjectMetadata {
-    /// The kind of item this is. For objects, this is always `storage#object`.
-    pub kind: Option<String>,
+pub struct Metadata {
     /// The ID of the object, including the bucket name, object name, and generation number.
     pub id: Option<String>,
     /// The link to this object.

--- a/src/v1/objects/mod.rs
+++ b/src/v1/objects/mod.rs
@@ -39,51 +39,66 @@ pub struct Object;
 #[serde(rename_all = "camelCase")]
 pub struct Metadata {
     /// The ID of the object, including the bucket name, object name, and generation number.
+    #[serde(skip_serializing)]
     pub id: Option<String>,
     /// The link to this object.
+    #[serde(skip_serializing)]
     pub self_link: Option<String>,
     /// The name of the object. Required if not specified by URL parameter. **writable**
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// The name of the bucket containing this object.
+    #[serde(skip_serializing)]
     pub bucket: Option<String>,
     /// The content generation of this object. Used for object versioning.
-    #[serde(default, deserialize_with = "from_str_opt")]
+    #[serde(default, skip_serializing, deserialize_with = "from_str_opt")]
     pub generation: Option<i64>,
     /// The version of the metadata for this object at this generation.
     /// Used for preconditions and for detecting changes in metadata.
     /// A metageneration number is only meaningful in the context of a
     /// particular generation of a particular object.
-    #[serde(default, deserialize_with = "from_str_opt")]
+    #[serde(default, skip_serializing, deserialize_with = "from_str_opt")]
     pub metageneration: Option<i64>,
     /// `Content-Type` of the object data. If an object is stored without
     /// a `Content-Type`, it is served as `application/octet-stream`. **writable**
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
     /// The creation time of the object in RFC 3339 format.
+    #[serde(skip_serializing)]
     pub time_created: Option<chrono::DateTime<chrono::Utc>>,
     /// The modification time of the object metadata in RFC 3339 format.
+    #[serde(skip_serializing)]
     pub updated: Option<chrono::DateTime<chrono::Utc>>,
     /// Storage class of the object. **writable**
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_class: Option<StorageClass>,
     /// The time at which the object's storage class was last changed.
     /// When the object is initially created, it will be set to timeCreated.
+    #[serde(skip_serializing)]
     pub time_storage_class_updated: Option<chrono::DateTime<chrono::Utc>>,
     /// `Content-Length` of the data in bytes.
-    #[serde(default, deserialize_with = "from_str_opt")]
+    #[serde(default, skip_serializing, deserialize_with = "from_str_opt")]
     pub size: Option<u64>,
     /// MD5 hash of the data; encoded using base64. For more information
     /// about using the MD5 hash, see Hashes and ETags: Best Practices. **writable**
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub md5_hash: Option<String>,
     /// Media download link.
+    #[serde(skip_serializing)]
     pub media_link: Option<String>,
-    /// `Content-Language` of the object data.
+    /// `Content-Language` of the object data. **writable**
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content_language: Option<String>,
     /// CRC32c checksum, as described in RFC 4960, Appendix B; encoded
     /// using base64 in big-endian byte order. For more information about
     /// using the CRC32c checksum, see Hashes and ETags: Best Practices.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub crc32c: Option<String>,
     /// HTTP 1.1 Entity tag for the object.
+    #[serde(skip_serializing)]
     pub etag: Option<String>,
     /// User-provided metadata, in key/value pairs. **writable**
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<BTreeMap<String, String>>,
 }
 

--- a/src/v1/objects/mod.rs
+++ b/src/v1/objects/mod.rs
@@ -1,3 +1,5 @@
+//! Types and APIs for interacting with GCS [Objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
 use crate::common::StorageClass;
 use std::collections::BTreeMap;
 
@@ -31,6 +33,8 @@ pub use get::*;
 pub use insert::*;
 pub use list::*;
 
+/// Helper struct used to collate all of the operations available for
+/// [Objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
 pub struct Object;
 
 /// [Metadata](https://cloud.google.com/storage/docs/json_api/v1/objects#resource)

--- a/tests/objects.rs
+++ b/tests/objects.rs
@@ -202,7 +202,7 @@ fn insert_multipart_text() {
         content_type: Some("text/plain".to_owned()),
         metadata: Some(
             ["akey"]
-                .into_iter()
+                .iter()
                 .map(|k| (String::from(*k), format!("{}value", k)))
                 .collect(),
         ),
@@ -268,7 +268,7 @@ fn multipart_read_paranoid() {
         content_type: Some("text/plain".to_owned()),
         metadata: Some(
             ["key_one", "key_two", "should_sort_first"]
-                .into_iter()
+                .iter()
                 .map(|k| (String::from(*k), format!("{}value", k)))
                 .collect(),
         ),

--- a/tests/objects.rs
+++ b/tests/objects.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use tame_gcs::{
     common::{Conditionals, StandardQueryParameters},
-    objects::{self, DeleteObjectOptional, InsertObjectOptional, Object},
+    objects::{self, DeleteObjectOptional, InsertObjectOptional, Metadata, Object},
     BucketName, ObjectId, ObjectName,
 };
 
@@ -189,4 +189,112 @@ fn parses_empty_list_response() {
 
     assert_eq!(0, list_response.objects.len());
     assert!(list_response.page_token.is_none());
+}
+
+const TEST_CONTENT: &str = include_str!("../CODE_OF_CONDUCT.md");
+
+#[test]
+fn insert_multipart_text() {
+    let body = TEST_CONTENT;
+
+    let metadata = Metadata {
+        name: Some("good_name".to_owned()),
+        content_type: Some("text/plain".to_owned()),
+        metadata: Some(
+            ["akey"]
+                .into_iter()
+                .map(|k| (String::from(*k), format!("{}value", k)))
+                .collect(),
+        ),
+        ..Default::default()
+    };
+
+    let insert_req = Object::insert_multipart(
+        &BucketName::non_validated("bucket"),
+        std::io::Cursor::new(body),
+        body.len() as u64,
+        &metadata,
+        None,
+    )
+    .unwrap();
+
+    // Example request from https://cloud.google.com/storage/docs/json_api/v1/how-tos/multipart-upload
+    // POST https://www.googleapis.com/upload/storage/v1/b/myBucket/o?uploadType=multipart HTTP/1.1
+    // Authorization: Bearer [YOUR_AUTH_TOKEN]
+    // Content-Type: multipart/related; boundary=foo_bar_baz
+    // Content-Length: [NUMBER_OF_BYTES_IN_ENTIRE_REQUEST_BODY]
+
+    // --foo_bar_baz
+    // Content-Type: application/json; charset=UTF-8
+
+    // {
+    // "name": "myObject"
+    // }
+
+    // --foo_bar_baz
+    // Content-Type: image/jpeg
+
+    // [JPEG_DATA]
+    // --foo_bar_baz--
+
+    // We use `tame_gcs` as the boundary
+
+    let expected_body = format!(
+        "--{b}\ncontent-type: application/json; charset=utf-8\n\n{}\n--{b}\ncontent-type: text/plain\n\n{}\n--{b}--",
+        serde_json::to_string(&metadata).unwrap(),
+        body,
+        b = "tame_gcs"
+    );
+
+    let expected = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://www.googleapis.com/upload/storage/v1/b/bucket/o?uploadType=multipart&prettyPrint=false")
+        .header(http::header::CONTENT_TYPE, "multipart/related; boundary=tame_gcs")
+        .header(http::header::CONTENT_LENGTH, 3549)
+        .body(std::io::Cursor::new(expected_body))
+        .unwrap();
+
+    util::requests_read_eq(insert_req, expected);
+}
+
+#[test]
+fn multipart_read_paranoid() {
+    // Ensure the Read implementation for Multipart works even with
+    // a (hopefully) unrealistic case of copying 1 byte at a time
+    let body = TEST_CONTENT;
+
+    let metadata = Metadata {
+        name: Some("a-really-descriptive-name".to_owned()),
+        content_type: Some("text/plain".to_owned()),
+        metadata: Some(
+            ["key_one", "key_two", "should_sort_first"]
+                .into_iter()
+                .map(|k| (String::from(*k), format!("{}value", k)))
+                .collect(),
+        ),
+        ..Default::default()
+    };
+
+    let mut mp =
+        objects::Multipart::wrap(std::io::Cursor::new(body), body.len() as u64, &metadata).unwrap();
+
+    let expected_body = format!(
+        "--{b}\ncontent-type: application/json; charset=utf-8\n\n{}\n--{b}\ncontent-type: text/plain\n\n{}\n--{b}--",
+        serde_json::to_string(&metadata).unwrap(),
+        body,
+        b = "tame_gcs"
+    );
+
+    use std::io::Read;
+    let mut actual_body = Vec::with_capacity(expected_body.len());
+    loop {
+        let mut buf = [0; 1];
+        if mp.read(&mut buf).unwrap() == 0 {
+            break;
+        }
+
+        actual_body.push(buf[0]);
+    }
+
+    util::cmp_strings(&expected_body, &String::from_utf8_lossy(&actual_body));
 }

--- a/tests/signed_url.rs
+++ b/tests/signed_url.rs
@@ -58,7 +58,7 @@ fn download_object() {
         )
         .expect("signed url");
 
-    let mut body = Vec::with_capacity(1 * 1024 * 1024);
+    let mut body = Vec::with_capacity(1024 * 1024);
 
     let mut response = Client::new()
         .get(signed)

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,11 +1,40 @@
 use http::Request;
+use std::io::Read;
 
-pub fn requests_eq<T: std::fmt::Debug>(actual: &Request<T>, expected: &Request<T>) {
+pub fn cmp_strings(expected: &str, actual: &str) {
+    if expected != actual {
+        let cs = difference::Changeset::new(expected, actual, "\n");
+        assert!(false, "{}", cs);
+    }
+}
+
+pub fn requests_eq<AB: std::fmt::Debug, EB: std::fmt::Debug>(
+    actual: &Request<AB>,
+    expected: &Request<EB>,
+) {
     let expected = format!("{:#?}", expected);
     let actual = format!("{:#?}", actual);
 
-    if expected != actual {
-        let cs = difference::Changeset::new(&expected, &actual, "\n");
-        assert!(false, "{}", cs);
-    }
+    cmp_strings(&expected, &actual);
+}
+
+pub fn requests_read_eq<AB: Read, EB: Read>(actual: Request<AB>, expected: Request<EB>) {
+    let (ap, mut ab) = actual.into_parts();
+    let (ep, mut eb) = expected.into_parts();
+
+    let expected = format!("{:#?}", ep);
+    let actual = format!("{:#?}", ap);
+
+    cmp_strings(&expected, &actual);
+
+    let mut act_bod = Vec::with_capacity(2 * 1024);
+    ab.read_to_end(&mut act_bod).unwrap();
+
+    let mut exp_bod = Vec::with_capacity(2 * 1024);
+    eb.read_to_end(&mut exp_bod).unwrap();
+
+    let act_body = String::from_utf8_lossy(&act_bod);
+    let exp_body = String::from_utf8_lossy(&exp_bod);
+
+    cmp_strings(&exp_body, &act_body);
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 pub fn cmp_strings(expected: &str, actual: &str) {
     if expected != actual {
         let cs = difference::Changeset::new(expected, actual, "\n");
-        assert!(false, "{}", cs);
+        panic!("{}", cs);
     }
 }
 


### PR DESCRIPTION
Multipart inserts allow inserting both metadata and content in a single request.

Also adds the drastically simplified `cp`, `ls` and `stat` sub-commands.