### PR TITLE
Upgrade to bytes 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Upgraded `bytes` to `0.5.3`
 - Upgraded `http` to `0.2.0`
 
 ## [0.5.2] - 2019-12-05

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 [dependencies]
 base64 = "0.11.0"
-bytes = "0.4.12"
+bytes = "0.5.3"
 chrono = { version = "0.4.10", features = ["serde"] }
 http = "0.2.0"
 percent-encoding = "2.1.0"

--- a/src/v1/objects/download.rs
+++ b/src/v1/objects/download.rs
@@ -58,10 +58,10 @@ impl std::ops::Deref for DownloadObjectResponse {
 
 impl io::Read for DownloadObjectResponse {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        use bytes::{Buf, IntoBuf};
+        use bytes::Buf;
 
         let buf_len = std::cmp::min(self.buffer.len(), buf.len());
-        let mut slice = self.buffer.split_to(buf_len).into_buf();
+        let mut slice = self.buffer.split_to(buf_len).to_bytes();
         slice.copy_to_slice(&mut buf[..buf_len]);
 
         Ok(buf_len)


### PR DESCRIPTION
This type is also part of the public API this crate so this would require a major version bump (0.x)