### PR TITLE
Fix Object::Patch bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,32 +23,32 @@ doctest = false
 
 [dependencies]
 base64 = "0.12"
-bytes = "0.5.3"
-chrono = { version = "0.4.10", features = ["serde"] }
-futures-util = { version = "0.3.0", optional = true, features = ["io"] }
+bytes = "0.5"
+chrono = { version = "0.4", features = ["serde"] }
+futures-util = { version = "0.3", optional = true, features = ["io"] }
 http = "0.2"
-percent-encoding = "2.1.0"
+percent-encoding = "2.1"
 pin-utils = { version = "0.1.0-alpha.4", optional = true }
 ring = { version = "0.16.9", optional = true }
-serde = { version = "1.0.101", features = ["derive"] }
-serde_json = "1.0.41"
-serde_urlencoded = "0.6.1"
-thiserror = "1.0.1"
-url = "2.1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_urlencoded = "0.6"
+thiserror = "1.0"
+url = "2.1"
 
 [dev-dependencies]
 # COLORS! (follows version used by clap)
 ansi_term = "0.11.0"
 # Friendly error handling
-anyhow = "1.0.11"
+anyhow = "1.0"
 # Human friendly byte sizes
-number_prefix = "0.3.0"
+number_prefix = "0.4"
 # Diff view of test failures
-difference = "2.0.0"
+difference = "2.0"
 # For futures helpers
-futures-util = { version = "0.3.0", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 # Futures testing utilities
-futures-test = { version = "0.3.0" }
+futures-test = { version = "0.3" }
 # Because it's good
 structopt = "0.3"
 # For doing actual authentication in examples

--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,7 @@ exceptions = [
     { allow = ["ISC"], name = "untrusted" },
     { allow = ["ISC"], name = "webpki" },
     { allow = ["ISC", "MIT", "OpenSSL"], name = "ring" },
+    { allow = ["Zlib"], name = "tinyvec" },
 ]
 
 [[licenses.clarify]]

--- a/examples/gsutil/ls.rs
+++ b/examples/gsutil/ls.rs
@@ -166,12 +166,12 @@ impl NormalPrinter {
             match self.display {
                 Display::Normal => println!("{}", Color::White.paint(filename)),
                 Display::Long => {
-                    use number_prefix::{NumberPrefix, PrefixNames, Prefixed, Standalone};
+                    use number_prefix::NumberPrefix;
 
                     let size_str = match NumberPrefix::decimal(item.size.unwrap_or_default() as f64)
                     {
-                        Standalone(b) => b.to_string(),
-                        Prefixed(p, n) => {
+                        NumberPrefix::Standalone(b) => b.to_string(),
+                        NumberPrefix::Prefixed(p, n) => {
                             if n < 10f64 {
                                 format!("{:.1}{}", n, p.symbol())
                             } else {
@@ -296,13 +296,11 @@ impl RecursePrinter {
                                 writeln!(out, "{}", Color::White.paint(scoped_name)).unwrap()
                             }
                             Display::Long => {
-                                use number_prefix::{
-                                    NumberPrefix, PrefixNames, Prefixed, Standalone,
-                                };
+                                use number_prefix::NumberPrefix;
 
                                 let size_str = match NumberPrefix::decimal(item.size as f64) {
-                                    Standalone(b) => b.to_string(),
-                                    Prefixed(p, n) => {
+                                    NumberPrefix::Standalone(b) => b.to_string(),
+                                    NumberPrefix::Prefixed(p, n) => {
                                         if n < 10f64 {
                                             format!("{:.1}{}", n, p.symbol())
                                         } else {

--- a/examples/gsutil/ls.rs
+++ b/examples/gsutil/ls.rs
@@ -157,7 +157,7 @@ impl NormalPrinter {
 
                     print_dir(self.display, dir);
 
-                    std::mem::replace(&mut next_dir, next_dir_iter.next());
+                    next_dir = next_dir_iter.next();
                 }
             }
 
@@ -201,7 +201,7 @@ impl NormalPrinter {
 
             print_dir(self.display, dir);
 
-            std::mem::replace(&mut next_dir, next_dir_iter.next());
+            next_dir = next_dir_iter.next();
         }
     }
 }

--- a/examples/gsutil/main.rs
+++ b/examples/gsutil/main.rs
@@ -7,6 +7,7 @@ mod cat;
 mod cp;
 mod ls;
 mod rm;
+mod setmeta;
 #[cfg(feature = "signing")]
 mod signurl;
 mod stat;
@@ -24,6 +25,8 @@ enum Command {
     Ls(ls::Args),
     #[structopt(name = "rm")]
     Rm(rm::Args),
+    #[structopt(name = "setmeta")]
+    SetMeta(setmeta::Args),
     #[cfg(feature = "signing")]
     #[structopt(name = "signurl")]
     Signurl(signurl::Args),
@@ -67,6 +70,7 @@ async fn real_main() -> Result<(), Error> {
         Command::Cp(args) => cp::cmd(&ctx, args).await,
         Command::Ls(args) => ls::cmd(&ctx, args).await,
         Command::Rm(args) => rm::cmd(&ctx, args).await,
+        Command::SetMeta(args) => setmeta::cmd(&ctx, args).await,
         #[cfg(feature = "signing")]
         Command::Signurl(args) => signurl::cmd(&ctx, args).await,
         Command::Stat(args) => stat::cmd(&ctx, args).await,

--- a/examples/gsutil/setmeta.rs
+++ b/examples/gsutil/setmeta.rs
@@ -1,0 +1,69 @@
+use crate::util;
+use anyhow::Error;
+use structopt::StructOpt;
+use tame_gcs::objects::Object;
+
+#[derive(StructOpt, Debug)]
+pub(crate) struct Args {
+    /// A valid JSON payload for the metadata to set
+    json: String,
+    /// The gs:// url to the object to set metadata for
+    url: url::Url,
+}
+
+pub(crate) async fn cmd(ctx: &util::RequestContext, args: Args) -> Result<(), Error> {
+    let oid = util::gs_url_to_object_id(&args.url)?;
+
+    let md: tame_gcs::objects::Metadata = serde_json::from_str(&args.json)?;
+
+    let set_req = Object::patch(
+        &(
+            oid.bucket(),
+            oid.object()
+                .ok_or_else(|| anyhow::anyhow!("invalid object name specified"))?,
+        ),
+        &md,
+        None,
+    )?;
+
+    let get_res: tame_gcs::objects::PatchObjectResponse = util::execute(ctx, set_req).await?;
+
+    let md = get_res.metadata;
+
+    // Print out the information the same way gsutil does, except with RFC-2822 date formatting
+    println!("{}", ansi_term::Color::Cyan.paint(args.url.as_str()));
+    println!(
+        "    Creation time:\t{}",
+        md.time_created.expect("time_created").to_rfc2822()
+    );
+    println!(
+        "    Update time:\t{}",
+        md.updated.expect("updated").to_rfc2822()
+    );
+    println!(
+        "    Storage class:\t{}",
+        md.storage_class.expect("storage_class")
+    );
+    println!("    Content-Length:\t{}", md.size.expect("size"));
+    println!(
+        "    Content-Type:\t{}",
+        md.content_type.as_deref().unwrap_or_else(|| "None")
+    );
+
+    if let Some(md) = &md.metadata {
+        for (k, v) in md {
+            println!("        {}:\t\t{}", k, v);
+        }
+    }
+
+    println!("    Hash (crc32c):\t{}", md.crc32c.expect("crc32c"));
+    println!("    Hash (md5):\t\t{}", md.md5_hash.expect("md5_hash"));
+    println!("    ETag:\t\t{}", md.etag.expect("etag"));
+    println!("    Generation:\t\t{}", md.generation.expect("generation"));
+    println!(
+        "    Metageneration:\t{}",
+        md.metageneration.expect("metageneration")
+    );
+
+    Ok(())
+}

--- a/examples/gsutil/stat.rs
+++ b/examples/gsutil/stat.rs
@@ -41,8 +41,15 @@ pub(crate) async fn cmd(ctx: &util::RequestContext, args: Args) -> Result<(), Er
     println!("    Content-Length:\t{}", md.size.expect("size"));
     println!(
         "    Content-Type:\t{}",
-        md.content_type.expect("content_type")
+        md.content_type.as_deref().unwrap_or_else(|| "None")
     );
+
+    if let Some(md) = &md.metadata {
+        for (k, v) in md {
+            println!("        {}:\t\t{}", k, v);
+        }
+    }
+
     println!("    Hash (crc32c):\t{}", md.crc32c.expect("crc32c"));
     println!("    Hash (md5):\t\t{}", md.md5_hash.expect("md5_hash"));
     println!("    ETag:\t\t{}", md.etag.expect("etag"));

--- a/examples/gsutil/util.rs
+++ b/examples/gsutil/util.rs
@@ -18,6 +18,7 @@ where
         http::Method::GET => client.get(&uri),
         http::Method::POST => client.post(&uri),
         http::Method::DELETE => client.delete(&uri),
+        http::Method::PATCH => client.patch(&uri),
         http::Method::PUT => client.put(&uri),
         method => unimplemented!("{} not implemented", method),
     };
@@ -89,7 +90,7 @@ where
 {
     // First, get our oauth token, which can mean we have to do an additional
     // request if we've never retrieved one yet, or the one we are using has expired
-    let token = match ctx.auth.get_token(&[tame_gcs::Scopes::ReadWrite])? {
+    let token = match ctx.auth.get_token(&[tame_gcs::Scopes::FullControl])? {
         oauth::TokenOrRequest::Token(token) => token,
         oauth::TokenOrRequest::Request {
             request,

--- a/src/v1/objects/patch.rs
+++ b/src/v1/objects/patch.rs
@@ -52,7 +52,8 @@ impl super::Object {
     where
         OID: ObjectIdentifier<'a> + ?Sized,
     {
-        let mut uri = crate::__make_obj_url!("https://www.googleapis.com/storage/v1/b/{}/o/{}", id);
+        let mut uri =
+            crate::__make_obj_url!("https://storage.googleapis.com/storage/v1/b/{}/o/{}", id);
 
         let query = optional.unwrap_or_default();
         let query_params = serde_urlencoded::to_string(query)?;
@@ -63,9 +64,15 @@ impl super::Object {
 
         let req_builder = http::Request::builder();
 
-        let md = serde_json::to_vec(metadata)?;
+        let md = serde_json::to_vec(&metadata)?;
+        let len = md.len();
         let md = std::io::Cursor::new(md);
 
-        Ok(req_builder.method("PATCH").uri(uri).body(md)?)
+        Ok(req_builder
+            .method("PATCH")
+            .header("content-type", "application/json")
+            .header("content-length", len)
+            .uri(uri)
+            .body(md)?)
     }
 }

--- a/tests/objects.rs
+++ b/tests/objects.rs
@@ -402,13 +402,17 @@ fn patches() {
         ..Default::default()
     };
 
+    let expected_len = serde_json::to_vec(&md).unwrap().len();
+
     let patch_req = Object::patch(&ObjectId::new("bucket", "object").unwrap(), &md, None).unwrap();
 
     let req_body = serde_json::to_vec(&md).unwrap();
 
     let expected = http::Request::builder()
         .method(http::Method::PATCH)
-        .uri("https://www.googleapis.com/storage/v1/b/bucket/o/object?prettyPrint=false")
+        .uri("https://storage.googleapis.com/storage/v1/b/bucket/o/object?prettyPrint=false")
+        .header("content-type", "application/json")
+        .header("content-length", expected_len)
         .body(std::io::Cursor::new(req_body))
         .unwrap();
 


### PR DESCRIPTION
It seems if you don't specify `content-length` when using `Object::patch` GCS just...nukes all of the metadata associated with an object. Fixed that issue, and added a simple setmeta subcommand to the gsutil example to actually play around and match what gsutil does.