### PR TITLE
Update lints to embark lints 0.3

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     #[error("Key rejected: {0}")]
     KeyRejected(String),
     #[error("An error occurred during signing")]
-    SigningError,
+    Signing,
     #[error("An expiration duration was too long: requested = {requested}, max = {max}")]
     TooLongExpiration { requested: u64, max: u64 },
     #[error("Failed to parse url")]
@@ -166,6 +166,6 @@ impl From<ring::error::KeyRejected> for Error {
 #[cfg(feature = "signing")]
 impl From<ring::error::Unspecified> for Error {
     fn from(_re: ring::error::Unspecified) -> Self {
-        Error::SigningError
+        Error::Signing
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,55 @@
-#![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
+// BEGIN - Embark standard lints v0.3
+// do not change or add/remove here, but one can add exceptions after this section
+// for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+#![deny(unsafe_code)]
+#![warn(
+    clippy::all,
+    clippy::await_holding_lock,
+    clippy::dbg_macro,
+    clippy::debug_assert_with_mut_call,
+    clippy::doc_markdown,
+    clippy::empty_enum,
+    clippy::enum_glob_use,
+    clippy::exit,
+    clippy::explicit_into_iter_loop,
+    clippy::filter_map_next,
+    clippy::fn_params_excessive_bools,
+    clippy::if_let_mutex,
+    clippy::imprecise_flops,
+    clippy::inefficient_to_string,
+    clippy::large_types_passed_by_value,
+    clippy::let_unit_value,
+    clippy::linkedlist,
+    clippy::lossy_float_literal,
+    clippy::macro_use_imports,
+    clippy::map_err_ignore,
+    clippy::map_flatten,
+    clippy::map_unwrap_or,
+    clippy::match_on_vec_items,
+    clippy::match_same_arms,
+    clippy::match_wildcard_for_single_variants,
+    clippy::mem_forget,
+    clippy::mismatched_target_os,
+    clippy::needless_borrow,
+    clippy::needless_continue,
+    clippy::option_option,
+    clippy::pub_enum_variant_names,
+    clippy::ref_option_ref,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::string_add_assign,
+    clippy::string_add,
+    clippy::string_to_string,
+    clippy::suboptimal_flops,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::unnested_or_patterns,
+    clippy::unused_self,
+    clippy::verbose_file_reads,
+    future_incompatible,
+    nonstandard_style,
+    rust_2018_idioms
+)]
+// END - Embark standard lints v0.3
 
 #[macro_use(Deserialize, Serialize)]
 extern crate serde;

--- a/src/response.rs
+++ b/src/response.rs
@@ -73,7 +73,7 @@ where
         }
     }
 
-    /// Try to get an http::Response
+    /// Try to get an [`http::Response`]
     pub fn get_response(mut self) -> Result<http::Response<bytes::Bytes>, Error> {
         if self.body.len() >= self.content_len {
             let buf = self.body.split_to(self.content_len);

--- a/src/signed_url.rs
+++ b/src/signed_url.rs
@@ -18,7 +18,7 @@ pub struct UrlSigner<D, S> {
 
 #[cfg(feature = "signing")]
 impl UrlSigner<signing::RingDigest, signing::RingSigner> {
-    /// Creates a UrlSigner implemented via `ring`
+    /// Creates a [`UrlSigner`] implemented via `ring`
     pub fn with_ring() -> UrlSigner<signing::RingDigest, signing::RingSigner> {
         UrlSigner::new(signing::RingDigest, signing::RingSigner)
     }
@@ -29,7 +29,7 @@ where
     D: signing::DigestCalulator,
     S: signing::Signer,
 {
-    /// Creates a new UrlSigner from a `DigestCalculator` implementation
+    /// Creates a new [`UrlSigner`] from a [`DigestCalculator`] implementation
     /// capable of generating SHA256 digests of buffers, and a `Signer`
     /// capable of doing RSA-SHA256 encryption. You may implement these
     /// on your own using whatever crates you prefer, or you can use the
@@ -44,7 +44,7 @@ where
     /// may succeed in generating a url, the actual operation using it may fail
     /// if the account used to sign the URL does not have sufficient permissions
     /// for the resource. For example, if you provided a GCP service account
-    /// that had devstorage.read_only permissions for the bucket/object, this method
+    /// that had `devstorage.read_only` permissions for the bucket/object, this method
     /// would succeed in generating a signed url for a `POST` operation, but the actual
     /// `POST` using that url would fail as the account does not itself have permissions
     /// for the `POST` operation.
@@ -113,7 +113,7 @@ where
 
                     key_vals.push_str(
                         val.to_str()
-                            .map_err(|_| Error::OpaqueHeaderValue(val.clone()))?,
+                            .map_err(|_err| Error::OpaqueHeaderValue(val.clone()))?,
                     );
                 }
 
@@ -226,9 +226,7 @@ where
             &mut digest,
         );
 
-        let mut digest_str_bytes = [0u8; 64];
-        let digest_str = crate::util::to_hex(&digest, &mut digest_str_bytes)
-            .expect("unable to construct digest string");
+        let digest_str = crate::util::to_hex(&digest);
 
         // 3. Construct the string-to-sign.
         // SIGNING_ALGORITHM
@@ -248,13 +246,11 @@ where
             string_to_sign.as_bytes(),
         )?;
 
-        let mut signature_str_bytes = vec![0; signature.len() * 2];
-        let signature_str = crate::util::to_hex(&signature, &mut signature_str_bytes)
-            .expect("unable to construct signature string");
+        let signature_str = crate::util::to_hex(&signature);
 
         signed_url
             .query_pairs_mut()
-            .append_pair("X-Goog-Signature", signature_str);
+            .append_pair("X-Goog-Signature", signature_str.as_str());
 
         // 4. Profit!
         Ok(signed_url)

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ pub struct BucketName<'a> {
 }
 
 impl<'a> BucketName<'a> {
-    /// Creates a BucketName without validating it, meaning
+    /// Creates a [`BucketName`] without validating it, meaning
     /// that invalid names will result in API failures when
     /// requests are actually made to GCS instead.
     pub fn non_validated<S: AsRef<str> + ?Sized>(name: &'a S) -> Self {
@@ -41,8 +41,7 @@ impl<'a> BucketName<'a> {
             }
 
             match c {
-                'a'..='z' => {}
-                '0'..='9' => {}
+                'a'..='z' | '0'..='9' => {}
                 '-' | '_' => {
                     // Bucket names must start and end with a number or letter.
                     if i == 0 || i == last {
@@ -121,7 +120,7 @@ pub struct ObjectName<'a> {
 }
 
 impl<'a> ObjectName<'a> {
-    /// Creates an ObjectName without validating it, meaning
+    /// Creates an `ObjectName` without validating it, meaning
     /// that invalid names will result in API failures when
     /// requests are actually made to GCS instead.
     pub fn non_validated<S: AsRef<str> + ?Sized>(name: &'a S) -> Self {
@@ -146,6 +145,8 @@ impl<'a> ObjectName<'a> {
             return Err(Error::InvalidPrefix("."));
         }
 
+        #[allow(clippy::match_same_arms)]
+        // Intentionally matching the same arms to make the code cleaner for reading
         for (i, c) in name.chars().enumerate() {
             match c {
                 // Object names cannot contain Carriage Return or Line Feed characters.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,31 +1,26 @@
 #![doc(hidden)]
 
-pub(crate) fn to_hex<'a>(input: &[u8], output: &'a mut [u8]) -> Option<&'a str> {
-    use std::str;
-
+pub(crate) fn to_hex(input: &[u8]) -> String {
     const CHARS: &[u8] = b"0123456789abcdef";
-
-    if output.len() < input.len() * 2 {
-        return None;
-    }
 
     let mut ind = 0;
 
+    let mut result = Vec::new();
     for &byte in input {
-        output[ind] = CHARS[(byte >> 4) as usize];
-        output[ind + 1] = CHARS[(byte & 0xf) as usize];
+        result[ind] = CHARS[(byte >> 4) as usize] as char;
+        result[ind + 1] = CHARS[(byte & 0xf) as usize] as char;
 
         ind += 2;
     }
 
-    unsafe { Some(str::from_utf8_unchecked(&output[0..input.len() * 2])) }
+    result.iter().collect()
 }
 
 pub fn get_content_length(headers: &http::HeaderMap) -> Option<usize> {
     headers.get(http::header::CONTENT_LENGTH).and_then(|h| {
         h.to_str()
-            .map_err(|_| ())
-            .and_then(|hv| hv.parse::<u64>().map(|l| l as usize).map_err(|_| ()))
+            .map_err(|_err| ())
+            .and_then(|hv| hv.parse::<u64>().map(|l| l as usize).map_err(|_err| ()))
             .ok()
     })
 }

--- a/src/v1/common.rs
+++ b/src/v1/common.rs
@@ -142,7 +142,7 @@ pub enum PredefinedAcl {
     PublicRead,
 }
 
-/// Set of properties to return. Defaults to NoAcl.
+/// Set of properties to return. Defaults to `NoAcl`.
 #[derive(Serialize, Copy, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum Projection {

--- a/src/v1/objects/mod.rs
+++ b/src/v1/objects/mod.rs
@@ -117,5 +117,5 @@ where
     use serde::de::Deserialize;
 
     let s: &str = Deserialize::deserialize(deserializer)?;
-    Ok(Some(T::from_str(&s).map_err(serde::de::Error::custom)?))
+    Ok(Some(T::from_str(s).map_err(serde::de::Error::custom)?))
 }


### PR DESCRIPTION
Fixes https://github.com/EmbarkStudios/tame-gcs/issues/45

One of the biggest changes impacts tests that have been ignored. I tried running them by removing the ignore, but they seem to rely on an ENV VAR that I don't have (TAME_GCS_TEST_SVC_ACCOUNT, TAME_GCS_TEST_BUCKET, TAME_GCS_TEST_OBJECT). These seem like things that maybe run in CI, but I couldn't see any references to that in the repo.