### PR TITLE
async-multipart: impl Stream for Multipart<Bytes>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ url = "2.2"
 [dev-dependencies]
 # Diff view of test failures
 difference = "2.0"
+futures = "0.3"
 futures-test = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 tokio = { version = "1.0", features = ["macros"] }


### PR DESCRIPTION
This allows for zero-copy when using hyper with https://docs.rs/hyper/0.14.10/hyper/struct.Body.html#method.wrap_stream