### PR TITLE
Fix deserialization of timestamps when not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#53](https://github.com/EmbarkStudios/tame-gcs/pull/53) fixed a bug in deserialization introduced by [PR#52](https://github.com/EmbarkStudios/tame-gcs/pull/52).
+
 ## [0.11.0] - 2022-02-02
 ### Added
 - [PR#51](https://github.com/EmbarkStudios/tame-gcs/pull/51) implemented `futures_util::Stream` for `Multipart<Bytes>`. Thanks [@shikhar](https://github.com/shikhar)!

--- a/src/v1/objects.rs
+++ b/src/v1/objects.rs
@@ -74,17 +74,17 @@ pub struct Metadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content_encoding: Option<String>,
     /// The creation time of the object in RFC 3339 format.
-    #[serde(skip_serializing, deserialize_with = "timestamp_rfc3339_opt")]
+    #[serde(default, skip_serializing, deserialize_with = "timestamp_rfc3339_opt")]
     pub time_created: Option<Timestamp>,
     /// The modification time of the object metadata in RFC 3339 format.
-    #[serde(skip_serializing, deserialize_with = "timestamp_rfc3339_opt")]
+    #[serde(default, skip_serializing, deserialize_with = "timestamp_rfc3339_opt")]
     pub updated: Option<Timestamp>,
     /// Storage class of the object. **writable**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_class: Option<StorageClass>,
     /// The time at which the object's storage class was last changed.
     /// When the object is initially created, it will be set to timeCreated.
-    #[serde(skip_serializing, deserialize_with = "timestamp_rfc3339_opt")]
+    #[serde(default, skip_serializing, deserialize_with = "timestamp_rfc3339_opt")]
     pub time_storage_class_updated: Option<Timestamp>,
     /// `Content-Length` of the data in bytes.
     #[serde(default, skip_serializing, deserialize_with = "from_str_opt")]


### PR DESCRIPTION
If object properties are filtered in the request the changes I made for the timestamps caused them to fail to deserialize, this fixes that.