### PR TITLE
Replace base64 with data-encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- [PR#63](https://github.com/EmbarkStudios/tame-gcs/pull/63) replaced `base64` with `data-encoding`.
+
 ## [0.12.1] - 2023-06-02
 ### Changed
 - [PR#62](https://github.com/EmbarkStudios/tame-gcs/pull/62) update the `base64` dependency from 0.13 to 0.21.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,15 +36,15 @@ async-multipart = ["futures-util", "pin-utils"]
 doctest = false
 
 [dependencies]
-# Follows version used by rustls
-base64 = "0.21"
+data-encoding = "2.4"
 # Follows version used by http
 bytes = "1.0"
 futures-util = { version = "0.3", optional = true, features = ["io"] }
 http = "0.2"
 percent-encoding = "2.1"
 pin-utils = { version = "0.1.0", optional = true }
-ring = { version = "0.16.16", optional = true }
+# Keep aligned with rustls
+ring = { version = "0.16", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ pub enum Error {
     #[error("I/O error occurred")]
     Io(#[source] IoError),
     #[error("Unable to decode base64")]
-    Base64Decode(#[source] base64::DecodeError),
+    Base64Decode(#[source] data_encoding::DecodeError),
     #[error("Unable to encode url")]
     UrlEncode(#[source] serde_urlencoded::ser::Error),
 }

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -108,8 +108,7 @@ impl ServiceAccount {
             },
         );
 
-        use base64::Engine;
-        let key_bytes = base64::engine::general_purpose::STANDARD
+        let key_bytes = data_encoding::BASE64
             .decode(key_string.as_bytes())
             .map_err(Error::Base64Decode)?;
 


### PR DESCRIPTION
The base64 API has gotten significantly worse so we are moving away from it in favor of data-encoding.