### PR TITLE
Upgrade `http` crate to `1.0.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ data-encoding = "2.4"
 # Follows version used by http
 bytes = "1.0"
 futures-util = { version = "0.3", optional = true, features = ["io"] }
-http = "0.2"
+http = "1"
 percent-encoding = "2.1"
 pin-utils = { version = "0.1.0", optional = true }
 # Keep aligned with rustls


### PR DESCRIPTION
The `http` crate has finally received its `1.0.0` release, but this does require some effort to propagate through the crates.
